### PR TITLE
Fix: recognize boolean value properly.

### DIFF
--- a/lib/embulk/parser/json.rb
+++ b/lib/embulk/parser/json.rb
@@ -46,7 +46,15 @@ module Embulk
             when "double"
               v.to_f
             when "boolean"
-              ["yes", "true", "1"].include?(v.downcase)
+              if v.nil?
+                nil
+              elsif v.kind_of?(String)
+                ["yes", "true", "1"].include?(v.downcase)
+              elsif v.kind_of?(Numeric)
+                !v.zero?
+              else
+                !!v
+              end
             when "timestamp"
               v.empty? ? nil : Time.strptime(v, c["format"])
             else


### PR DESCRIPTION
Enabled to accept boolean, numeric, and string values as boolean specified property.
