### PR TITLE
Fix to be able to parse TrueClass and FalseClass as type: boolean

### DIFF
--- a/lib/embulk/parser/jsonpath.rb
+++ b/lib/embulk/parser/jsonpath.rb
@@ -47,7 +47,9 @@ module Embulk
             when "json"
               val
             when "boolean"
-              if val.nil? || val.empty?
+              if kind_of_boolean?(val)
+                val
+              elsif val.nil? || val.empty?
                 nil
               elsif val.kind_of?(String)
                 ["yes", "true", "1"].include?(val.downcase)
@@ -62,6 +64,10 @@ module Embulk
               raise "Unsupported type #{type}"
           end
         end
+      end
+
+      def kind_of_boolean?(val)
+        val.kind_of?(TrueClass) || val.kind_of?(FalseClass)
       end
     end
   end


### PR DESCRIPTION
I found out that when I try parsing boolean type, `embulk-parser-json` can parse `"true"`(as String) but cannot `true`(as TrueClass)
I prepared following config and json and got `Error: undefined method 'empty?' for true:TrueClass`.

config.yml

```
in:
  type: file
  path_prefix: ./boolean_test.json
  parser:
    type: jsonpath
    root: $
    schema:
    - {name: enabled, type: boolean}

out:
  type: stdout
```

boolean_test.json

```
[
  {
    "enabled": true
  },
  {
    "enabled": false
  }
]
```

result

```
-> % embulk preview config.yml
2017-01-09 14:05:22.022 +0900: Embulk v0.8.15
2017-01-09 14:05:22.606 +0900 [INFO] (0001:preview): Listing local files at directory '.' filtering filename by prefix 'boolean_test.json'
2017-01-09 14:05:22.610 +0900 [INFO] (0001:preview): Loading files [boolean_test.json]
2017-01-09 14:05:22.665 +0900 [INFO] (0001:preview): Loaded plugin embulk-parser-json (0.0.4)
undefined method `empty?' for true:TrueClass
    /Users/yoan/.embulk/jruby/2.3.0/gems/embulk-parser-json-0.0.4/lib/embulk/parser/jsonpath.rb:55:in `block in make_record'
    org/jruby/RubyArray.java:2492:in `map'
    /Users/yoan/.embulk/jruby/2.3.0/gems/embulk-parser-json-0.0.4/lib/embulk/parser/jsonpath.rb:34:in `make_record'
    /Users/yoan/.embulk/jruby/2.3.0/gems/embulk-parser-json-0.0.4/lib/embulk/parser/jsonpath.rb:26:in `block in run'
    org/jruby/RubyArray.java:1734:in `each'
    /Users/yoan/.embulk/jruby/2.3.0/gems/embulk-parser-json-0.0.4/lib/embulk/parser/jsonpath.rb:25:in `run'
    /Users/yoan/bin/embulk!/embulk/parser_plugin.rb:56:in `run'
    /Users/yoan/bin/embulk!/embulk/parser_plugin.rb:45:in `block in transaction'
    /Users/yoan/.embulk/jruby/2.3.0/gems/embulk-parser-json-0.0.4/lib/embulk/parser/jsonpath.rb:18:in `transaction'
    /Users/yoan/bin/embulk!/embulk/parser_plugin.rb:42:in `transaction'
    /Users/yoan/bin/embulk!/embulk/runner.rb:35:in `preview'
    /Users/yoan/bin/embulk!/embulk/command/embulk_run.rb:305:in `run'
    /Users/yoan/bin/embulk!/embulk/command/embulk_main.rb:2:in `<main>'
    org/jruby/RubyKernel.java:956:in `require'
    uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1:in `(root)'
    file:/Users/yoan/bin/embulk!/embulk/command/embulk_bundle.rb:51:in `<main>'

Error: undefined method `empty?' for true:TrueClass
```

So, I added  boolean check before nil check.